### PR TITLE
[chore] 배포 서버를 위한 의존성 패키지 버전 변경

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 aioredis==1.3.1
 annotated-types==0.7.0
-anyio==4.8.0
+anyio==4.6.2
 appendonly==1.2
 asgiref==3.8.1
 async-timeout==5.0.1
 attrs==25.1.0
-autobahn==24.4.2
+autobahn==23.1.2
 Automat==24.8.1
 boto3==1.36.16
 botocore==1.36.16
@@ -45,7 +45,7 @@ pyasn1_modules==0.4.1
 pycparser==2.22
 pydantic==2.10.6
 pydantic_core==2.27.2
-PyJWT==2.10.1
+PyJWT==2.9.0
 pyOpenSSL==25.0.0
 python-dateutil==2.9.0.post0
 pytz==2024.2
@@ -63,10 +63,10 @@ Twisted==24.11.0
 txaio==23.1.1
 typing_extensions==4.12.2
 tzdata==2025.1
-urllib3==2.3.0
-whitenoise==6.8.2
+urllib3==1.26.18
+whitenoise==6.7.0
 zc.lockfile==3.0.post1
-ZConfig==4.2
+ZConfig==4.1
 ZODB==6.0
 zodbpickle==4.1.1
 zope.deferredimport==5.0


### PR DESCRIPTION
현재 배포 서버에서 의존성 파일을 install 하면 안되는게 너무 많기에 버전 변경으로 배포가 가능하도록 설정